### PR TITLE
Fix broken linkedin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### Connect with me:
 
 [<img align="left" alt="krunal-ctrl | Twitter" src="https://img.shields.io/badge/-twitter-black?style=for-the-badge&logo=twitter" />](https://twitter.com/jethva_krunal)
-[<img align="left" alt="krunal-ctrl | LinkedIn" src="https://img.shields.io/badge/-linkedin-black?style=for-the-badge&logo=linkedin" />](www.linkedin.com/in/krunal-jethva)
+[<img align="left" alt="krunal-ctrl | LinkedIn" src="https://img.shields.io/badge/-linkedin-black?style=for-the-badge&logo=linkedin" />](https://www.linkedin.com/in/krunal-jethva)
 [<img align="left" alt="krunal-ctrl | Instagram" src="https://img.shields.io/badge/-instagram-black?style=for-the-badge&logo=instagram" />](https://instagram.com/krunal_jethva_14)
 [<img align="left" alt="krunal-ctrl | Email" src="https://img.shields.io/badge/-mail-black?style=for-the-badge&logo=gmail" />](mailto:krunaljethva90@gmail.com)
 <br />


### PR DESCRIPTION
The linkedin link was missing the protocol, causing it to link to a nonexistent file in the repository rather than linkedin. This commit adds the missing https